### PR TITLE
refactor: Remove Toast duration on CreateProjectModal, Add Password field option on InputField

### DIFF
--- a/src/renderer/src/components/InputField.tsx
+++ b/src/renderer/src/components/InputField.tsx
@@ -11,6 +11,7 @@ interface InputFieldProps {
   value?: string
   onChange?: (value: string) => void
   size?: 'md' | 'sm'
+  password?: boolean
 }
 
 const InputField = ({
@@ -22,7 +23,8 @@ const InputField = ({
   titleBold = false,
   value,
   onChange,
-  size = 'md'
+  size = 'md',
+  password = false
 }: InputFieldProps): ReactElement => {
   const [inputValue, setInputValue] = useState(value || '')
 
@@ -93,7 +95,7 @@ const InputField = ({
           {required && <span className="input-field-required">*</span>}
         </div>
         <input
-          type="text"
+          type={password ? 'password' : 'text'}
           className="input-field-input"
           placeholder={placeholder}
           value={inputValue}

--- a/src/renderer/src/modals/CreateProjectModal.tsx
+++ b/src/renderer/src/modals/CreateProjectModal.tsx
@@ -260,6 +260,7 @@ DBMS: ${formData.dbType}
             required={true}
             value={formData.password}
             onChange={(value) => handleInputChange('password', value)}
+            password={true}
           />
         </div>
         <div className="create-project-modal-button-container">
@@ -282,7 +283,6 @@ DBMS: ${formData.dbType}
             <Toast
               type={toastType}
               title={toastType === 'success' ? '연결 성공' : '입력 오류'}
-              duration={3000}
               onClose={() => setShowToast(false)}
             >
               <div className="toast-text">{toastMessage}</div>

--- a/src/renderer/src/views/InfoView.tsx
+++ b/src/renderer/src/views/InfoView.tsx
@@ -39,35 +39,30 @@ const InfoView: React.FC = () => {
       setToastType('warning')
       setToastMessage('프로젝트명을 입력해주세요.')
       setShowToast(true)
-      setTimeout(() => setShowToast(false), 3000)
       return false
     }
     if (!formData.host.trim()) {
       setToastType('warning')
       setToastMessage('호스트를 입력해주세요.')
       setShowToast(true)
-      setTimeout(() => setShowToast(false), 3000)
       return false
     }
     if (!formData.port.trim()) {
       setToastType('warning')
       setToastMessage('포트를 입력해주세요.')
       setShowToast(true)
-      setTimeout(() => setShowToast(false), 3000)
       return false
     }
     if (!formData.username.trim()) {
       setToastType('warning')
       setToastMessage('사용자명을 입력해주세요.')
       setShowToast(true)
-      setTimeout(() => setShowToast(false), 3000)
       return false
     }
     if (!formData.password.trim()) {
       setToastType('warning')
       setToastMessage('비밀번호를 입력해주세요.')
       setShowToast(true)
-      setTimeout(() => setShowToast(false), 3000)
       return false
     }
     return true
@@ -81,9 +76,6 @@ const InfoView: React.FC = () => {
     setToastType('success')
     setToastMessage('데이터베이스 연결에 성공했습니다.')
     setShowToast(true)
-    setTimeout(() => {
-      setShowToast(false)
-    }, 3000)
   }
 
   const handleInputChange = (field: keyof ProjectInfo, value: string): void => {
@@ -223,6 +215,7 @@ const InfoView: React.FC = () => {
             required={true}
             value={formData.password}
             onChange={(value) => handleInputChange('password', value)}
+            password={true}
           />
         </div>
         <div className="info-view-button-container">
@@ -245,7 +238,7 @@ const InfoView: React.FC = () => {
             <Toast
               type={toastType}
               title={toastType === 'success' ? '연결 성공' : '입력 오류'}
-              duration={3000}
+              onClose={() => setShowToast(false)}
             >
               <div className="toast-text">{toastMessage}</div>
             </Toast>


### PR DESCRIPTION
## ✨ 작업 내용

CreateProjectModal, InfoView의 Toast Duration을 제거했습니다. 사용자가 닫기 버튼을 누르면 닫힙니다.
InputField에 Password를 도입했습니다.

  <br/>

## 💬 리뷰 요구사항 (선택)

InputField password={true}로 설정 시 비밀번호 필드로 변경

  <br/>

## 📸 이미지 첨부 (선택)

<img width="1419" height="1101" alt="image" src="https://github.com/user-attachments/assets/4ef75cea-d5c4-415c-aef0-1199376e84a0" />

<br/>

## 🎫 지라

- Closes S13P31B201-티켓번호

<br/>
