### PR TITLE
fix: Disable overlay click close in modal

### DIFF
--- a/src/renderer/src/components/Modal.tsx
+++ b/src/renderer/src/components/Modal.tsx
@@ -20,7 +20,7 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, width = '790px
 
   return (
     <>
-      <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-overlay">
         <div className="modal-container" style={{ width }} onClick={(e) => e.stopPropagation()}>
           <button className="modal-close" onClick={onClose}>
             ✕


### PR DESCRIPTION
## ✨ 작업 내용

> 기능에서 어떤 부분이 구현되었는지 설명해주세요.

  <br/>

모달 오버레이 클릭시 닫히지 않게 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 모달에서 배경 클릭으로 닫히는 동작이 제거되었습니다. 모달은 이제 닫기 버튼 또는 Escape 키를 통해서만 닫을 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->