### PR TITLE
[fix] disable RunAsNode fuse and use utilityProcess for worker execution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@electron-toolkit/eslint-config-prettier": "^3.0.0",
         "@electron-toolkit/eslint-config-ts": "^3.1.0",
         "@electron-toolkit/tsconfig": "^2.0.0",
+        "@electron/fuses": "^2.1.0",
         "@electron/rebuild": "^4.0.1",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^22.19.0",
@@ -550,6 +551,19 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/@electron/fuses": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-2.1.0.tgz",
+      "integrity": "sha512-6Mhtz2xYPkiZrunCBo2RoXYSx+yGj/km6n6rTOi71srw0LFpRkfMJ7EpjMuPrXOZv7fCos81idf1lYDqwHALqw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "electron-fuses": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@electron/get": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "build:unpack": "npm run build && electron-builder --dir",
     "build:win": "npm run build && electron-builder --win",
     "build:mac": "electron-vite build && electron-builder --mac",
-    "build:linux": "electron-vite build && electron-builder --linux"
+    "build:linux": "electron-vite build && electron-builder --linux",
+    "postpack": "node scripts/flip-fuses.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.68.0",
@@ -51,6 +52,7 @@
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",
     "@electron-toolkit/eslint-config-ts": "^3.1.0",
     "@electron-toolkit/tsconfig": "^2.0.0",
+    "@electron/fuses": "^2.1.0",
     "@electron/rebuild": "^4.0.1",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.19.0",
@@ -83,10 +85,6 @@
         "filter": [
           "*.sql"
         ]
-      },
-      {
-        "from": "build/node/node.exe",
-        "to": "bin/node.exe"
       }
     ],
     "directories": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:win": "npm run build && electron-builder --win",
     "build:mac": "electron-vite build && electron-builder --mac",
     "build:linux": "electron-vite build && electron-builder --linux",
-    "postpack": "node scripts/fuses.mjs"
+    "postpack": "node scripts/fuse.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.68.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:win": "npm run build && electron-builder --win",
     "build:mac": "electron-vite build && electron-builder --mac",
     "build:linux": "electron-vite build && electron-builder --linux",
-    "postpack": "node scripts/flip-fuses.mjs"
+    "postpack": "node scripts/fuses.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.68.0",

--- a/scripts/fuse.mjs
+++ b/scripts/fuse.mjs
@@ -1,0 +1,9 @@
+import { flipFuses, FuseVersion, FuseV1Options } from '@electron/fuses'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+
+await flipFuses(require.resolve('electron'), {
+  version: FuseVersion.V1,
+  [FuseV1Options.RunAsNode]: false
+})

--- a/src/main/services/data-generator/data-generator-service.ts
+++ b/src/main/services/data-generator/data-generator-service.ts
@@ -164,6 +164,7 @@ export async function runDataGenerator(
         sqlPath: '',
         error: (err as Error).message
       })
+      startNext()
     }
   }
 

--- a/src/main/services/data-generator/data-generator-service.ts
+++ b/src/main/services/data-generator/data-generator-service.ts
@@ -1,7 +1,6 @@
 ﻿import path from 'node:path'
 import os from 'node:os'
-import { spawn } from 'node:child_process'
-import { app, BrowserWindow } from 'electron'
+import { app, BrowserWindow, utilityProcess } from 'electron'
 import type { WorkerTask, WorkerResult, GenerateRequest, GenerationResult } from '@shared/types'
 import { getDatabaseByProjectId } from '../../database/databases'
 import { getDBMSById } from '../../database/dbms'
@@ -83,108 +82,89 @@ export async function runDataGenerator(
       : undefined
 
   const queue = [...tables]
-  const running = new Set<ReturnType<typeof spawn>>()
+  const running = new Set<ReturnType<typeof utilityProcess.fork>>()
   const results: WorkerResult[] = []
   const cacheRoot = getFileCacheRoot()
 
   const startNext = async (): Promise<void> => {
-    if (queue.length === 0) return
-    const table = queue.shift()!
+    try {
+      if (queue.length === 0) return
+      const table = queue.shift()!
 
-    const task: WorkerTask = {
-      projectId,
-      dbType: dbTypeKey,
-      table,
-      schema,
-      database: databaseInfo,
-      rules,
-      mode,
-      connection: connectionInfo,
-      skipInvalidRows: payload.skipInvalidRows ?? true
-    }
-    const isPackaged = app.isPackaged
-    const baseDir = isPackaged
-      ? fs.existsSync(path.join(process.resourcesPath, 'app.asar.unpacked'))
-        ? path.join(process.resourcesPath, 'app.asar.unpacked')
-        : path.join(process.resourcesPath, 'app')
-      : app.getAppPath()
-
-    const workerPath = path.join(baseDir, 'out', 'main', 'worker-runner.js')
-
-    const nodeBinary = path.join(process.resourcesPath, 'bin', 'node.exe')
-
-    const child = spawn(nodeBinary, [workerPath], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: {
-        ...process.env,
-        TASK: JSON.stringify(task),
-        HERESDUMMY_CACHE_DIR: cacheRoot
+      const task: WorkerTask = {
+        projectId,
+        dbType: dbTypeKey,
+        table,
+        schema,
+        database: databaseInfo,
+        rules,
+        mode,
+        connection: connectionInfo,
+        skipInvalidRows: payload.skipInvalidRows ?? true
       }
-    })
-    running.add(child)
+      const isPackaged = app.isPackaged
+      const baseDir = isPackaged
+        ? fs.existsSync(path.join(process.resourcesPath, 'app.asar.unpacked'))
+          ? path.join(process.resourcesPath, 'app.asar.unpacked')
+          : path.join(process.resourcesPath, 'app')
+        : app.getAppPath()
 
-    let stdout = ''
-    let stdoutBuffer = ''
-    let stderr = ''
+      const workerPath = path.join(baseDir, 'out', 'main', 'worker-runner.js')
 
-    child.stdout.on('data', (data) => {
-      const chunk = data.toString()
-      process.stdout.write(chunk)
-      stdout += chunk
+      const child = utilityProcess.fork(workerPath, [], {
+        stdio: 'pipe',
+        env: {
+          ...process.env,
+          HERESDUMMY_CACHE_DIR: cacheRoot
+        },
+        serviceName: 'Data Generator Worker'
+      })
+      running.add(child)
 
-      stdoutBuffer += chunk
-      let newlineIndex: number
-      while ((newlineIndex = stdoutBuffer.indexOf('\n')) !== -1) {
-        const line = stdoutBuffer.slice(0, newlineIndex).trim()
-        stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1)
-        if (!line) continue
+      child.postMessage({
+        type: 'start',
+        task
+      })
 
-        if (line.startsWith('{') && line.endsWith('}')) {
-          try {
-            const msg = JSON.parse(line)
-            if (msg.type) {
-              mainWindow.webContents.send('data-generator:progress', msg)
-            }
-          } catch (err) {
-            void err
+      let stderr = ''
+
+      // 완료 행 수 받아서 진행 상황 프론트로 보내기
+      child.on('message', (data) => {
+        if (data.type) {
+          if (data.type === 'worker-result') {
+            results.push(data.result)
+          } else {
+            mainWindow.webContents.send('data-generator:progress', data)
           }
         }
-      }
-    })
+      })
 
-    child.stderr.on('data', (data) => {
-      stderr += data.toString()
-      console.error('[worker] stderr:', data.toString())
-    })
+      child.stderr?.on('data', (data) => {
+        stderr += data.toString()
+        console.error('[worker] stderr:', data.toString())
+      })
 
-    child.on('close', (code) => {
-      running.delete(child)
-      if (code === 0) {
-        // stdout 안에서 success 포함 JSON 객체 전부 추출
-        const matches = stdout.match(/\{[^}]*"success"[^}]*\}/g)
-
-        if (matches && matches.length > 0) {
-          // 가장 마지막 JSON이 최종 결과 JSON
-          const finalJson = matches[matches.length - 1]
-          results.push(JSON.parse(finalJson))
-        } else {
+      child.on('exit', (code) => {
+        running.delete(child)
+        if (code !== 0) {
           results.push({
             success: false,
             tableName: table.tableName,
             sqlPath: '',
-            error: 'Worker finished without a valid result JSON.'
+            error: stderr || `Worker exited with code ${code}`
           })
         }
-      } else {
-        results.push({
-          success: false,
-          tableName: table.tableName,
-          sqlPath: '',
-          error: stderr || `Worker exited with code ${code}`
-        })
-      }
-      startNext()
-    })
+        startNext()
+      })
+    } catch (err) {
+      logger.error('startNext 실패', err)
+      results.push({
+        success: false,
+        tableName: 'unknown',
+        sqlPath: '',
+        error: (err as Error).message
+      })
+    }
   }
 
   for (let i = 0; i < Math.min(MAX_PARALLEL, queue.length); i++) {

--- a/src/main/services/data-generator/worker-runner.ts
+++ b/src/main/services/data-generator/worker-runner.ts
@@ -512,12 +512,10 @@ async function runWorker(task: WorkerTask): Promise<WorkerResult> {
                 failedOnThisChunk++
 
                 // UI-friendly message only
-                process.stdout.write(
-                  JSON.stringify({
-                    type: 'row-error',
-                    tableName
-                  }) + '\n'
-                )
+                process.parentPort.postMessage({
+                  type: 'row-error',
+                  tableName
+                })
 
                 // skipInvalidRows === false → 즉시 중단
                 if (task.skipInvalidRows === false) {
@@ -531,14 +529,12 @@ async function runWorker(task: WorkerTask): Promise<WorkerResult> {
         totalProcessed += successOnThisChunk // 성공한 row만 증가
         totalFailed += failedOnThisChunk // fallback에서 실패한 row
 
-        process.stdout.write(
-          JSON.stringify({
-            type: 'row-delta',
-            tableName,
-            success: successOnThisChunk,
-            fail: failedOnThisChunk
-          }) + '\n'
-        )
+        process.parentPort.postMessage({
+          type: 'row-delta',
+          tableName,
+          success: successOnThisChunk,
+          fail: failedOnThisChunk
+        })
 
         await fs.promises.appendFile(sqlPath, bulkSQL + '\n', 'utf8')
       }
@@ -549,26 +545,22 @@ async function runWorker(task: WorkerTask): Promise<WorkerResult> {
       const progressPercent =
         chunkIdx + 1 === numChunks ? 100 : Math.floor((chunkEnd / recordCnt) * 100)
 
-      process.stdout.write(
-        JSON.stringify({
-          type: 'row-progress',
-          tableName,
-          progress: progressPercent
-        }) + '\n'
-      )
+      process.parentPort.postMessage({
+        type: 'row-progress',
+        tableName,
+        progress: progressPercent
+      })
 
       await new Promise((res) => setTimeout(res, 100))
 
       if (chunkEnd === recordCnt) {
         columns.forEach((col) => {
-          process.stdout.write(
-            JSON.stringify({
-              type: 'column-progress',
-              tableName,
-              columnName: col.columnName,
-              progress: 100
-            }) + '\n'
-          )
+          process.parentPort.postMessage({
+            type: 'column-progress',
+            tableName,
+            columnName: col.columnName,
+            progress: 100
+          })
         })
       }
     }
@@ -584,15 +576,13 @@ async function runWorker(task: WorkerTask): Promise<WorkerResult> {
       directContext = null
     }
 
-    process.stdout.write(
-      JSON.stringify({
-        type: 'table-complete',
-        tableName,
-        totalRows: recordCnt,
-        successRows: totalProcessed,
-        failedRows: totalFailed
-      }) + '\n'
-    )
+    process.parentPort.postMessage({
+      type: 'table-complete',
+      tableName,
+      totalRows: recordCnt,
+      successRows: totalProcessed,
+      failedRows: totalFailed
+    })
 
     const result: WorkerResult = {
       tableName,
@@ -600,7 +590,7 @@ async function runWorker(task: WorkerTask): Promise<WorkerResult> {
       success: true,
       directInserted: directMode ? true : undefined
     }
-    console.log('\n' + JSON.stringify(result) + '\n')
+    process.parentPort.postMessage({ type: 'worker-result', result: result })
     return result
   } catch (err) {
     if (directContext) {
@@ -616,33 +606,41 @@ async function runWorker(task: WorkerTask): Promise<WorkerResult> {
       error: (err as Error).message
     }
     logger.error('worker-runner error:', err)
-    console.log(JSON.stringify(result))
+    process.parentPort.postMessage({ type: 'worker-result', result: result })
     return result
   }
 }
 
 async function main(): Promise<void> {
-  const taskEnv = process.env.TASK
-  if (!taskEnv) {
-    logger.error('TASK environment variable is missing.')
-    process.exit(1)
-  }
+  process.parentPort?.once('message', async (event) => {
+    try {
+      const data = event.data
 
-  const task = JSON.parse(taskEnv)
-  const result = await runWorker(task)
+      if (!data || typeof data !== 'object' || data.type !== 'start') {
+        logger.error('Invalid start message')
+        process.exit(1)
+      }
 
-  try {
-    const fd = await fs.promises.open(result.sqlPath, 'r+')
-    await fd.sync()
-    await fd.close()
-    logger.info(`[FLUSH] ${result.tableName} flush complete`)
-  } catch (e) {
-    logger.warn('fsync failed:', e)
-  }
+      const task = data.task as WorkerTask
+      const result = await runWorker(task)
 
-  await new Promise((res) => setTimeout(res, 500))
+      try {
+        const fd = await fs.promises.open(result.sqlPath, 'r+')
+        await fd.sync()
+        await fd.close()
+        logger.info(`[FLUSH] ${result.tableName} flush complete`)
+      } catch (e) {
+        logger.warn('fsync failed:', e)
+      }
 
-  process.exit(result.success ? 0 : 1)
+      await new Promise((res) => setTimeout(res, 500))
+
+      process.exit(result.success ? 0 : 1)
+    } catch (err) {
+      logger.error('worker main error: ', err)
+      process.exit(1)
+    }
+  })
 }
 
 main()


### PR DESCRIPTION
## ✨ 작업 내용

> 기능에서 어떤 부분이 구현되었는지 설명해주세요.
- Worker 실행 시 `node.exe` 내부 경로(`resources/bin/node.exe`)를 직접 참조하던 로직 제거
- 기존 `spawn(node.exe)` 기반 worker 실행 구조를 `utilityProcess.fork()`기반으로 변경
- 특정 `node.exe` 경로에 의존하지 않도록 worker 실행 구조 수정
- `RunAsNode` fuse 비활성화 (`@electron/fuses`)
- Node.js가 깔린 윈도우 환경과 Node.js가 깔리지 않은 윈도우 환경에서 각각 MySQL, PostgreSQL로 SQL문 생성과 DB 직접 삽입 테스트 정상 작동 확인
  <br/>

## 🔍 변경 이유

기존 구현에서는 Worker 프로세스를 실행하기 위해 Node를 빌드에 포함시키고 해당 `node.exe`를 직접 실행하여 `worker-runner.js`를 실행하는 구조였습니다.

이 방식은 다음과 같은 문제가 있었습니다.

- `node.exe` 경로를 직접 관리해야 함
- dev / packaged 환경에 따라 실행 경로를 다르게 처리하지 않아 dev 환경에서는 해당 경로가 존재하지 않아 데이터 생성 기능 실행 시 worker가 시작되지 않고 `resources\bin\node.exe ENOENT` 오류가 발생함
- Worker와의 통신을 stdout 기반으로 처리해야 하므로 JSON 파싱 등의 추가 로직이 필요함

dev 환경에서는 개인 PC의 Node를 찾아 실행하도록 해결할 수도 있었지만 Node 실행 경로 관리 문제가 계속 남게 됩니다.

대신 Electron에서 권장하는 방식인 `utilityProcess`를 사용하도록 구조를 변경했습니다.

`utilityProcess.fork()`를 사용하면

- 외부 `node.exe` 실행 없이 Worker 스크립트를 실행할 수 있어 Node 경로 의존이 사라지고
- 메인 프로세스와 메시지 기반 IPC(`postMessage`)로 통신할 수 있어 stdout 파싱 로직이 필요 없어지며
- node 실행 경로를 따로 신경쓰지 않아도 되어 dev / packaged 환경 모두 동일한 방식으로 Worker를 실행할 수 있습니다.

따라서 Worker 실행 구조를 `utilityProcess.fork(worker-runner.js)` 기반으로 변경하여 환경 의존적인 실행 구조를 제거하고 통신 방식도 메시지 기반으로 정리했습니다.

또한 Worker 실행 방식 변경과 함께 `RunAsNode` fuse도 비활성화했습니다.

Electron에서는 `ELECTRON_RUN_AS_NODE` 환경 변수를 설정하면 Electron 실행 파일을 Node.js 실행기처럼 사용할 수 있습니다.  
하지만 이 기능은 공격자가 Electron 앱을 Node 실행기로 악용하여 임의 JavaScript 실행을 유도할 수 있는 보안 문제가 있을 수 있습니다.

Electron 공식 문서에서도 이러한 이유로 `RunAsNode` 기능을 fuse로 비활성화하는 것을 권장하고 있으며, 대신 별도 작업을 수행할 경우 `utilityProcess` 사용을 권장하고 있습니다.

따라서 Worker 실행 구조를 `utilityProcess` 기반으로 변경하는 것과 함께 `RunAsNode` fuse를 비활성화하여 Electron 실행 파일이 Node 실행기로 사용되지 않도록 설정했습니다.

<br/>

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.  
- Worker 실행 구조 변경이 기존 기능에 영향이 없는지 확인 부탁드립니다.

  <br/>

## 기타(선택)

- Closes #181 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **Refactor**
  * 데이터 생성 워커를 메시지 기반 통신으로 전환하여 안정성, 오류 보고, 병렬 처리 및 실패 복구 개선.

* **Chores**
  * 빌드 후처리 스크립트 추가 및 전용 개발 도구 추가로 배포 관련 처리 강화.
  * 불필요한 빌드 리소스 매핑 제거 및 빌드 스크립트 형식 정리.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->