### PR TITLE
[fix] correct progress calculation for worker-based data generation

### DIFF
--- a/src/main/services/data-generator/data-generator-service.ts
+++ b/src/main/services/data-generator/data-generator-service.ts
@@ -44,7 +44,10 @@ export async function runDataGenerator(
   const schema = await fetchSchema(projectId)
 
   const ruleIds = new Set<number>()
+  let totalRows = 0
+  let progressRows = 0
   for (const table of tables) {
+    totalRows += table.recordCnt
     for (const column of table.columns) {
       if (
         (column.dataSource === 'FAKER' || column.dataSource === 'AI') &&
@@ -133,6 +136,11 @@ export async function runDataGenerator(
         if (data.type) {
           if (data.type === 'worker-result') {
             results.push(data.result)
+          } else if (data.type === 'row-progress') {
+            progressRows += data.progress
+            const progress = Math.floor((progressRows / totalRows) * 100)
+            data.progress = progress
+            mainWindow.webContents.send('data-generator:progress', data)
           } else {
             mainWindow.webContents.send('data-generator:progress', data)
           }

--- a/src/main/services/data-generator/data-generator-service.ts
+++ b/src/main/services/data-generator/data-generator-service.ts
@@ -59,6 +59,10 @@ export async function runDataGenerator(
     }
   }
 
+  if (totalRows === 0) {
+    throw new Error('Total row count is 0. No data to generate.')
+  }
+
   let successRows = 0
   let failedRows = 0
 

--- a/src/main/services/data-generator/data-generator-service.ts
+++ b/src/main/services/data-generator/data-generator-service.ts
@@ -59,6 +59,9 @@ export async function runDataGenerator(
     }
   }
 
+  let successRows = 0
+  let failedRows = 0
+
   const rules = Array.from(ruleIds)
     .map((id) => getRuleById(id))
     .filter((rule): rule is NonNullable<typeof rule> => Boolean(rule))
@@ -140,6 +143,10 @@ export async function runDataGenerator(
             progressRows += data.progress
             const progress = Math.floor((progressRows / totalRows) * 100)
             data.progress = progress
+            mainWindow.webContents.send('data-generator:progress', data)
+          } else if (data.type === 'table-complete') {
+            successRows += data.successRows
+            failedRows += data.failedRows
             mainWindow.webContents.send('data-generator:progress', data)
           } else {
             mainWindow.webContents.send('data-generator:progress', data)
@@ -226,7 +233,10 @@ export async function runDataGenerator(
   mainWindow.webContents.send('data-generator:progress', {
     type: 'all-complete',
     successCount: successResults.length,
-    failCount: failedResults.length
+    failCount: failedResults.length,
+    successRows: successRows,
+    failedRows: failedRows,
+    totalRows: totalRows
   })
 
   const allErrors = failedResults.map((r) => `[${r.tableName}] ${r.error ?? 'Unknown error'}`)

--- a/src/main/services/data-generator/data-generator-service.ts
+++ b/src/main/services/data-generator/data-generator-service.ts
@@ -15,6 +15,12 @@ import { createLogger } from '../../utils/logger'
 const logger = createLogger('data-generator-service')
 const MAX_PARALLEL = Math.max(1, Math.floor(os.cpus().length / 2))
 
+/**
+ * 데이터 생성 전체 흐름을 관리하는 메인 함수
+ * - Worker 실행
+ * - 진행률 전달
+ * - SQL ZIP 생성
+ */
 export async function runDataGenerator(
   payload: GenerateRequest,
   mainWindow: BrowserWindow
@@ -96,6 +102,9 @@ export async function runDataGenerator(
   const results: WorkerResult[] = []
   const cacheRoot = getFileCacheRoot()
 
+  /**
+   * 다음 테이블 작업을 Worker로 실행
+   */
   const startNext = async (): Promise<void> => {
     try {
       if (queue.length === 0) return
@@ -255,6 +264,9 @@ export async function runDataGenerator(
   }
 }
 
+/**
+ * DB URL에서 host와 port 추출
+ */
 function parseDatabaseUrl(rawUrl: string, dbType: SupportedDBMS): { host: string; port: number } {
   const defaultPort = dbType === 'mysql' ? 3306 : 5432
 
@@ -283,7 +295,9 @@ function parseDatabaseUrl(rawUrl: string, dbType: SupportedDBMS): { host: string
   }
 }
 
-// 재시도 기반 파일 삭제
+/**
+ * 파일 잠금 시 재시도하며 삭제
+ */
 async function deleteWithRetry(filePath: string, maxRetries = 3, delayMs = 500): Promise<void> {
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {

--- a/src/main/services/data-generator/worker-runner.ts
+++ b/src/main/services/data-generator/worker-runner.ts
@@ -459,13 +459,11 @@ async function runWorker(task: WorkerTask): Promise<WorkerResult> {
               `[행 변환 오류] ${tableName} ${totalProcessed + rowIdx + 1}행 변환 실패`
             )
           }
+        } else if (!directMode) {
+          totalProcessed++
         }
 
         rows.push(`(${rowValues.join(', ')})`)
-
-        if (!directMode) {
-          totalProcessed++
-        }
       }
 
       // === DIRECT_DB bulk insert + fallback ===

--- a/src/main/services/data-generator/worker-runner.ts
+++ b/src/main/services/data-generator/worker-runner.ts
@@ -347,7 +347,6 @@ async function runWorker(task: WorkerTask): Promise<WorkerResult> {
     }
 
     logger.info(`[${tableName}] 시작: ${recordCnt.toLocaleString()}행, ${columns.length}컬럼`)
-    const startTime = Date.now()
     let totalProcessed = 0
     const numChunks = Math.max(1, Math.ceil(recordCnt / CHUNK_SIZE))
 
@@ -359,22 +358,16 @@ async function runWorker(task: WorkerTask): Promise<WorkerResult> {
         continue
       }
 
-      logger.info(`\n[${tableName}] 청크 ${chunkIdx + 1}/${numChunks} 처리 중 (${chunkSize}행)`)
-      const chunkStartTime = Date.now()
-
       const columnStreams = columns.map((col) => createColumnStream(col, task, chunkSize))
       const { aiColumns, nonAiColumns } = separateColumnsByType(columns)
       const chunkColumnValues: (string | typeof INVALID)[][] = new Array(columns.length)
 
       // === Non-AI 컬럼 처리 (예외 처리 일관화) ===
       if (nonAiColumns.length > 0) {
-        logger.info(`[${tableName}] Non-AI 컬럼 동시 처리:`)
         const nonAiResults = await Promise.all(
           nonAiColumns.map(async (colIdx) => {
             const col = columns[colIdx]
             const stream = columnStreams[colIdx]
-            const colStart = Date.now()
-            logger.info(`  ▶ [${col.columnName}] 처리 (${col.dataSource})`)
 
             const values: (string | typeof INVALID)[] = []
             for (let i = 0; i < chunkSize; i++) {
@@ -394,9 +387,6 @@ async function runWorker(task: WorkerTask): Promise<WorkerResult> {
               }
             }
 
-            const colDuration = ((Date.now() - colStart) / 1000).toFixed(2)
-            logger.info(`  ✓ [${col.columnName}] 완료 (${colDuration}초)`)
-
             return { colIdx, values }
           })
         )
@@ -408,8 +398,6 @@ async function runWorker(task: WorkerTask): Promise<WorkerResult> {
 
       // === AI 컬럼 처리 (동시 MAX_AI_CONCURRENT개, 예외 처리 통일) ===
       if (aiColumns.length > 0) {
-        logger.info(`[${tableName}] AI 컬럼 처리 (동시 ${MAX_AI_CONCURRENT}개):`)
-
         for (let i = 0; i < aiColumns.length; i += MAX_AI_CONCURRENT) {
           const batch = aiColumns.slice(i, i + MAX_AI_CONCURRENT)
 
@@ -417,8 +405,6 @@ async function runWorker(task: WorkerTask): Promise<WorkerResult> {
             batch.map(async (colIdx) => {
               const col = columns[colIdx]
               const stream = columnStreams[colIdx]
-              const colStart = Date.now()
-              logger.info(`  ▶ [${col.columnName}] 처리 (${col.dataSource})`)
 
               const values: (string | typeof INVALID)[] = []
               for (let j = 0; j < chunkSize; j++) {
@@ -438,9 +424,6 @@ async function runWorker(task: WorkerTask): Promise<WorkerResult> {
                 }
               }
 
-              const colDuration = ((Date.now() - colStart) / 1000).toFixed(2)
-              logger.info(`  ✓ [${col.columnName}] 완료 (${colDuration}초)`)
-
               return { colIdx, values }
             })
           )
@@ -450,7 +433,6 @@ async function runWorker(task: WorkerTask): Promise<WorkerResult> {
           })
 
           if (i + MAX_AI_CONCURRENT < aiColumns.length) {
-            logger.info(`  … 다음 AI 컬럼 대기 (1초)...`)
             await new Promise((res) => setTimeout(res, 1000))
           }
         }
@@ -529,46 +511,17 @@ async function runWorker(task: WorkerTask): Promise<WorkerResult> {
         totalProcessed += successOnThisChunk // 성공한 row만 증가
         totalFailed += failedOnThisChunk // fallback에서 실패한 row
 
-        process.parentPort.postMessage({
-          type: 'row-delta',
-          tableName,
-          success: successOnThisChunk,
-          fail: failedOnThisChunk
-        })
-
         await fs.promises.appendFile(sqlPath, bulkSQL + '\n', 'utf8')
       }
-
-      const chunkDuration = ((Date.now() - chunkStartTime) / 1000).toFixed(2)
-      logger.info(`\n[${tableName}] 청크 ${chunkIdx + 1} 완료 (${chunkDuration}초)`)
-
-      const progressPercent =
-        chunkIdx + 1 === numChunks ? 100 : Math.floor((chunkEnd / recordCnt) * 100)
 
       process.parentPort.postMessage({
         type: 'row-progress',
         tableName,
-        progress: progressPercent
+        progress: chunkSize
       })
 
       await new Promise((res) => setTimeout(res, 100))
-
-      if (chunkEnd === recordCnt) {
-        columns.forEach((col) => {
-          process.parentPort.postMessage({
-            type: 'column-progress',
-            tableName,
-            columnName: col.columnName,
-            progress: 100
-          })
-        })
-      }
     }
-
-    const totalDuration = ((Date.now() - startTime) / 1000).toFixed(2)
-    logger.info(
-      `\n[${tableName}] 전체 완료 (${totalDuration}초, ${totalProcessed.toLocaleString()}행)`
-    )
 
     if (directContext) {
       await directContext.commit()

--- a/src/main/services/data-generator/worker-runner.ts
+++ b/src/main/services/data-generator/worker-runner.ts
@@ -26,7 +26,10 @@ const logger = createLogger('worker-runner')
 const INVALID = { __invalid: true } as const
 type CellValue = string | typeof INVALID
 
-// 컬럼별 스트림 생성 함수
+/**
+ * 컬럼 설정에 따라 데이터 생성 스트림을 반환
+ * (FAKER, AI, FILE, FIXED, REFERENCE)
+ */
 function createColumnStream(
   col: {
     columnName: string
@@ -146,7 +149,9 @@ function createColumnStream(
   }
 }
 
-// AI 컬럼과 non-AI 컬럼 분리
+/**
+ * 컬럼 목록을 AI / non-AI 인덱스로 분리
+ */
 function separateColumnsByType(columns: { dataSource: DataSourceType }[]): {
   aiColumns: number[]
   nonAiColumns: number[]
@@ -280,6 +285,9 @@ type DirectContext = {
   close: () => Promise<void>
 }
 
+/**
+ * DIRECT_DB 모드에서 사용할 DB 연결 컨텍스트 생성
+ */
 async function createDirectContext(
   dbType: keyof typeof DBMS_MAP,
   connection: NonNullable<WorkerTask['connection']>
@@ -322,6 +330,12 @@ async function createDirectContext(
   }
 }
 
+/**
+ * 테이블 단위 데이터 생성 Worker
+ * - 컬럼 스트림 생성
+ * - 행 조립
+ * - SQL 파일 생성 또는 DB 삽입
+ */
 async function runWorker(task: WorkerTask): Promise<WorkerResult> {
   const { table, dbType, mode, connection } = task
   const { tableName, recordCnt, columns } = table

--- a/src/renderer/src/views/DummyInsertView.tsx
+++ b/src/renderer/src/views/DummyInsertView.tsx
@@ -86,11 +86,6 @@ const DummyInsertView: React.FC = () => {
         setProgress(message.progress)
       }
 
-      if (message.type === 'row-delta') {
-        setSuccessRows((prev) => prev + (message.successDelta ?? 0))
-        setFailedRows((prev) => prev + (message.failDelta ?? 0))
-      }
-
       if (message.type === 'table-complete' && message.tableName) {
         const hasFail = (message.failedRows ?? 0) > 0
 

--- a/src/renderer/src/views/DummyInsertView.tsx
+++ b/src/renderer/src/views/DummyInsertView.tsx
@@ -89,13 +89,9 @@ const DummyInsertView: React.FC = () => {
       if (message.type === 'table-complete' && message.tableName) {
         const hasFail = (message.failedRows ?? 0) > 0
 
-        setTotalRows((prev) => prev + (message.totalRows ?? 0))
-        setSuccessRows((prev) => prev + (message.successRows ?? 0))
-        setFailedRows((prev) => prev + (message.failedRows ?? 0))
-
         setTables((prev) =>
           prev.map((t) =>
-            t.name === message.tableName ? { ...t, status: hasFail ? 'warning' : 'success' } : t
+            t.name === message.tableName ? { ...t, status: hasFail ? 'failure' : 'success' } : t
           )
         )
       }
@@ -322,7 +318,7 @@ const DummyInsertView: React.FC = () => {
             </>
           ) : (
             <>
-              <p style={{ font: 'var(--preBold20)', marginBottom: 16 }}>더미데이터 삽입 완료</p>
+              <p style={{ font: 'var(--preBold20)', marginBottom: 16 }}>더미데이터 생성 완료</p>
               <p style={{ marginBottom: 20 }}>
                 전체 {totalCount.toLocaleString()}개 중 {insertedCount.toLocaleString()}개 완료
               </p>


### PR DESCRIPTION
## ✨ 작업 내용

> 기능에서 어떤 부분이 구현되었는지 설명해주세요.

- worker 기반 데이터 생성 시 진행률 계산 방식을 워커별 progress 이벤트 그대로 반영하던 방식을 제거
- 전체 완료 row 수 기준으로 진행률을 계산하도록 변경
- 불필요한 info 레벨의 log들 삭제

  <br/>

## 🔍 변경 이유

기존 구현에서는 각 워커가 전달하는 진행률 값을 그대로 반영하여 전체 진행률을 계산했습니다.
하지만 워커 이벤트는 비동기적으로 도착하기 때문에 늦게 도착한 낮은 진행률 값이 UI에 반영되면서 진행률이 증가했다가 감소하는 현상이 발생했습니다.
이를 해결하기 위해 전체 완료된 row 수를 기준으로 진행률을 계산하도록 로직을 변경했습니다.

<br/>

## 기타(선택)

Closes #185 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 진행률 이벤트에 총행(totalRows), 성공행(successRows), 실패행(failedRows) 메트릭이 추가되어 더 상세한 진행 정보 제공
* **버그 수정**
  * 파일 삭제와 정리 작업의 재시도/백오프 개선으로 작업 실패 감소
* **개선**
  * 전체 진행률 계산 및 행 단위 진행 보고가 정확해짐
  * 불필요한 상세 로그 제거로 출력이 간결해짐
  * 완료 상태 텍스트 및 실패 상태 표시 방식이 사용자용으로 정비됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->